### PR TITLE
feat: allow sorting on any field with runtime sort fallback

### DIFF
--- a/lib/ash_dynamo/data_layer.ex
+++ b/lib/ash_dynamo/data_layer.ex
@@ -98,42 +98,7 @@ defmodule AshDynamo.DataLayer do
   @impl true
   def sort(query, [], _resource), do: {:ok, query}
   def sort(query, nil, _resource), do: {:ok, query}
-
-  def sort(query, sort, resource) do
-    sort_key = Info.sort_key(resource)
-
-    case validate_sort(sort, sort_key) do
-      {:ok, direction} ->
-        {:ok, %{query | sort: direction}}
-
-      {:error, reason} ->
-        {:error, reason}
-    end
-  end
-
-  defp validate_sort([{field, direction}], sort_key) when direction in [:asc, :desc] do
-    field_name = attr_name(field)
-
-    cond do
-      is_nil(sort_key) ->
-        {:error, "Cannot sort without a sort key defined on the resource"}
-
-      field_name != sort_key ->
-        {:error,
-         "DynamoDB only supports sorting by the sort key (#{sort_key}), got: #{field_name}"}
-
-      true ->
-        {:ok, direction}
-    end
-  end
-
-  defp validate_sort([{_field, _direction} | _rest], _sort_key) do
-    {:error, "DynamoDB only supports sorting by a single field (the sort key)"}
-  end
-
-  defp validate_sort(sort, _sort_key) do
-    {:error, "Unsupported sort format: #{inspect(sort)}"}
-  end
+  def sort(query, sort, _resource), do: {:ok, %{query | sort: sort}}
 
   # --- Execution ----------------------------------------------------------
   @impl true
@@ -143,7 +108,7 @@ defmodule AshDynamo.DataLayer do
 
     {mode, opts} = request_opts(query, resource)
     opts = merge_projection_opts(opts, select_fields)
-    opts = merge_sort_opts(opts, query.sort, mode)
+    opts = merge_sort_opts(opts, query.sort, mode, resource)
 
     result =
       mode
@@ -154,18 +119,69 @@ defmodule AshDynamo.DataLayer do
       |> ExAws.request()
 
     with {:ok, resp} <- result,
-         {:ok, items} <- decode_items(resp, resource) do
-      apply_runtime_filter(items, query)
+         {:ok, items} <- decode_items(resp, resource),
+         {:ok, filtered} <- apply_runtime_filter(items, query) do
+      apply_runtime_sort(filtered, query, mode, resource)
     end
   end
 
   # DynamoDB's ScanIndexForward parameter controls sort order for Query operations.
   # true (default) = ascending by sort key, false = descending.
-  # This only applies to Query mode; Scan returns items in no particular order.
-  defp merge_sort_opts(opts, nil, _mode), do: opts
-  defp merge_sort_opts(opts, :asc, :query), do: Keyword.put(opts, :scan_index_forward, true)
-  defp merge_sort_opts(opts, :desc, :query), do: Keyword.put(opts, :scan_index_forward, false)
-  defp merge_sort_opts(opts, _sort, :scan), do: opts
+  #
+  # ScanIndexForward optimization only applies when ALL conditions are met:
+  # - Query mode (partition key filter present)
+  # - Sorting by a SINGLE field
+  # - That field is the sort key
+  #
+  # All other cases use runtime sort:
+  # - Scan mode (no partition key filter)
+  # - Sorting by non-sort-key field
+  # - Multiple sort fields (even if sort key is included)
+  defp merge_sort_opts(opts, nil, _mode, _resource), do: opts
+  defp merge_sort_opts(opts, [], _mode, _resource), do: opts
+
+  defp merge_sort_opts(opts, [{field, direction}], :query, resource) do
+    sort_key = Info.sort_key(resource)
+
+    if attr_name(field) == sort_key do
+      case direction do
+        :asc -> Keyword.put(opts, :scan_index_forward, true)
+        :desc -> Keyword.put(opts, :scan_index_forward, false)
+      end
+    else
+      opts
+    end
+  end
+
+  defp merge_sort_opts(opts, _sort, _mode, _resource), do: opts
+
+  # Runtime sort is applied when DynamoDB cannot natively sort the results:
+  # - Scan mode: ScanIndexForward doesn't work
+  # - Query mode with non-sort-key field: DynamoDB can only sort by the sort key
+  # In Query mode when sorting by sort key, DynamoDB handles sorting via ScanIndexForward.
+  defp apply_runtime_sort(results, %Query{sort: nil}, _mode, _resource), do: {:ok, results}
+  defp apply_runtime_sort(results, %Query{sort: []}, _mode, _resource), do: {:ok, results}
+
+  defp apply_runtime_sort(results, %Query{sort: sort}, mode, resource) do
+    sort_key = Info.sort_key(resource)
+
+    sorting_by_sort_key? =
+      case sort do
+        [{field, _}] -> attr_name(field) == sort_key
+        _ -> false
+      end
+
+    if mode == :query and sorting_by_sort_key? do
+      {:ok, results}
+    else
+      # rekey?: false prevents Ash from matching sorted records back to originals
+      # by primary key. Without this, records sharing the same Ash primary key
+      # (e.g., same partition key but different sort keys) would all resolve to
+      # the first match, duplicating records in the output.
+      sorted = Ash.Actions.Sort.runtime_sort(results, sort, rekey?: false)
+      {:ok, sorted}
+    end
+  end
 
   @impl true
   def create(resource, changeset) do

--- a/test/sort_test.exs
+++ b/test/sort_test.exs
@@ -126,26 +126,231 @@ defmodule AshDynamo.Test.SortTest do
     end
   end
 
-  describe "sort validation errors" do
-    test "returns error when sorting on resource without sort key" do
-      query = Ash.Query.sort(Post, inserted_at: :desc)
+  describe "runtime sort (Scan mode)" do
+    test "sorts posts in descending order without partition key filter" do
+      # Create posts with different emails to ensure Scan mode (no PK filter)
+      post1 =
+        generate(
+          post_sort_key(
+            email: "aaa@example.com",
+            status: "active",
+            inserted_at: "2024-01-01T00:00:00Z"
+          )
+        )
 
-      assert {:error, error} = Ash.read(query)
-      assert Exception.message(error) =~ "Cannot sort without a sort key"
+      post2 =
+        generate(
+          post_sort_key(
+            email: "bbb@example.com",
+            status: "active",
+            inserted_at: "2024-01-02T00:00:00Z"
+          )
+        )
+
+      post3 =
+        generate(
+          post_sort_key(
+            email: "ccc@example.com",
+            status: "active",
+            inserted_at: "2024-01-03T00:00:00Z"
+          )
+        )
+
+      # Query without PK filter forces Scan mode, runtime sort applies
+      query = Ash.Query.sort(PostSortKey, inserted_at: :desc)
+
+      {:ok, results} = Ash.read(query)
+
+      assert length(results) == 3
+      assert Enum.at(results, 0).inserted_at == post3.inserted_at
+      assert Enum.at(results, 1).inserted_at == post2.inserted_at
+      assert Enum.at(results, 2).inserted_at == post1.inserted_at
     end
 
-    test "returns error when sorting on non-sort-key field" do
-      query = Ash.Query.sort(PostSortKey, status: :desc)
+    test "sorts posts in ascending order without partition key filter" do
+      post1 =
+        generate(
+          post_sort_key(
+            email: "aaa@example.com",
+            status: "active",
+            inserted_at: "2024-01-01T00:00:00Z"
+          )
+        )
 
-      assert {:error, error} = Ash.read(query)
-      assert Exception.message(error) =~ "DynamoDB only supports sorting by the sort key"
+      post2 =
+        generate(
+          post_sort_key(
+            email: "bbb@example.com",
+            status: "active",
+            inserted_at: "2024-01-02T00:00:00Z"
+          )
+        )
+
+      post3 =
+        generate(
+          post_sort_key(
+            email: "ccc@example.com",
+            status: "active",
+            inserted_at: "2024-01-03T00:00:00Z"
+          )
+        )
+
+      query = Ash.Query.sort(PostSortKey, inserted_at: :asc)
+
+      {:ok, results} = Ash.read(query)
+
+      assert length(results) == 3
+      assert Enum.at(results, 0).inserted_at == post1.inserted_at
+      assert Enum.at(results, 1).inserted_at == post2.inserted_at
+      assert Enum.at(results, 2).inserted_at == post3.inserted_at
+    end
+  end
+
+  describe "runtime sort for non-sort-key fields (Query mode)" do
+    test "sorts by non-sort-key field in descending order", %{email: email} do
+      post1 =
+        generate(
+          post_sort_key(
+            email: email,
+            status: "aaa",
+            inserted_at: "2024-01-01T00:00:00Z"
+          )
+        )
+
+      post2 =
+        generate(
+          post_sort_key(
+            email: email,
+            status: "bbb",
+            inserted_at: "2024-01-02T00:00:00Z"
+          )
+        )
+
+      post3 =
+        generate(
+          post_sort_key(
+            email: email,
+            status: "ccc",
+            inserted_at: "2024-01-03T00:00:00Z"
+          )
+        )
+
+      # Query mode (PK filter) + sort by non-sort-key field (status)
+      query =
+        PostSortKey
+        |> Ash.Query.filter(email == ^email)
+        |> Ash.Query.sort(status: :desc)
+
+      {:ok, results} = Ash.read(query)
+
+      assert length(results) == 3
+      assert Enum.at(results, 0).status == post3.status
+      assert Enum.at(results, 1).status == post2.status
+      assert Enum.at(results, 2).status == post1.status
     end
 
-    test "returns error when sorting on multiple fields" do
-      query = Ash.Query.sort(PostSortKey, inserted_at: :desc, status: :asc)
+    test "sorts by non-sort-key field in ascending order", %{email: email} do
+      post1 =
+        generate(
+          post_sort_key(
+            email: email,
+            status: "aaa",
+            inserted_at: "2024-01-01T00:00:00Z"
+          )
+        )
 
-      assert {:error, error} = Ash.read(query)
-      assert Exception.message(error) =~ "DynamoDB only supports sorting by a single field"
+      post2 =
+        generate(
+          post_sort_key(
+            email: email,
+            status: "bbb",
+            inserted_at: "2024-01-02T00:00:00Z"
+          )
+        )
+
+      post3 =
+        generate(
+          post_sort_key(
+            email: email,
+            status: "ccc",
+            inserted_at: "2024-01-03T00:00:00Z"
+          )
+        )
+
+      query =
+        PostSortKey
+        |> Ash.Query.filter(email == ^email)
+        |> Ash.Query.sort(status: :asc)
+
+      {:ok, results} = Ash.read(query)
+
+      assert length(results) == 3
+      assert Enum.at(results, 0).status == post1.status
+      assert Enum.at(results, 1).status == post2.status
+      assert Enum.at(results, 2).status == post3.status
+    end
+  end
+
+  describe "runtime sort on resource without sort key" do
+    test "sorts by any field on resource without sort key" do
+      post1 = generate(post(status: "aaa"))
+      post2 = generate(post(status: "bbb"))
+      post3 = generate(post(status: "ccc"))
+
+      query = Ash.Query.sort(Post, status: :desc)
+
+      {:ok, results} = Ash.read(query)
+
+      assert length(results) == 3
+      assert Enum.at(results, 0).status == post3.status
+      assert Enum.at(results, 1).status == post2.status
+      assert Enum.at(results, 2).status == post1.status
+    end
+  end
+
+  describe "multiple sort fields (always runtime sort)" do
+    test "sorts by multiple fields using runtime sort", %{email: email} do
+      # Same status, different inserted_at - tests secondary sort
+      post1 =
+        generate(
+          post_sort_key(
+            email: email,
+            status: "active",
+            inserted_at: "2024-01-01T00:00:00Z"
+          )
+        )
+
+      post2 =
+        generate(
+          post_sort_key(
+            email: email,
+            status: "active",
+            inserted_at: "2024-01-02T00:00:00Z"
+          )
+        )
+
+      post3 =
+        generate(
+          post_sort_key(
+            email: email,
+            status: "inactive",
+            inserted_at: "2024-01-03T00:00:00Z"
+          )
+        )
+
+      # Sort by status desc, then by inserted_at asc
+      # Expected order: inactive (post3), then active posts by inserted_at asc (post1, post2)
+      query =
+        PostSortKey
+        |> Ash.Query.filter(email == ^email)
+        |> Ash.Query.sort(status: :desc, inserted_at: :asc)
+
+      {:ok, results} = Ash.read(query)
+
+      assert length(results) == 3
+      assert Enum.at(results, 0).inserted_at == post3.inserted_at
+      assert Enum.at(results, 1).inserted_at == post1.inserted_at
+      assert Enum.at(results, 2).inserted_at == post2.inserted_at
     end
   end
 end


### PR DESCRIPTION
- Remove sort field validation to match ETS/Mnesia/Simple data layers
- Use ScanIndexForward optimization only when sorting by sort key in Query mode
- Fall back to Ash.Actions.Sort.runtime_sort for all other cases:
  - Scan mode (no partition key filter)
  - Non-sort-key fields in Query mode
  - Multiple sort fields
- Add rekey?: false to prevent duplicate records when Ash primary key differs from DynamoDB composite key

Closes https://github.com/rauann/ash_dynamo/issues/11